### PR TITLE
Fixes #28, Fixes #29: Resolve SSR build failure from Plyr library

### DIFF
--- a/src/components/FileListing.tsx
+++ b/src/components/FileListing.tsx
@@ -30,7 +30,6 @@ import MarkdownPreview from './previews/MarkdownPreview'
 import CodePreview from './previews/CodePreview'
 import OfficePreview from './previews/OfficePreview'
 import AudioPreview from './previews/AudioPreview'
-import VideoPreview from './previews/VideoPreview'
 import PDFPreview from './previews/PDFPreview'
 import URLPreview from './previews/URLPreview'
 import ImagePreview from './previews/ImagePreview'
@@ -42,6 +41,9 @@ import FolderGridLayout from './FolderGridLayout'
 
 // Disabling SSR for some previews
 const EPUBPreview = dynamic(() => import('./previews/EPUBPreview'), {
+  ssr: false,
+})
+const VideoPreview = dynamic(() => import('./previews/VideoPreview'), {
   ssr: false,
 })
 


### PR DESCRIPTION
Fixes #28, Fixes #29: Resolve SSR build failure from Plyr library
The build was failing with a `ReferenceError: document is not defined` because the `plyr` video player library, which is client-side only, was being executed during Server-Side Rendering (SSR).
This has been resolved by dynamically importing the component that uses `plyr` with the `ssr: false` option. This ensures the library is only initialized in the browser environment.